### PR TITLE
docs: refine roadmap and remove news-please

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,32 @@
 # freshrss-application
 
+An experimental playground for running [FreshRSS](https://freshrss.org/) with a
+PostgreSQL backend.  The repository packages the application and database in a
+single Docker Compose stack and ships the documentation used by the
+development team.
 
 ## Setup
 
+1. Copy `.env.example` to `.env` and adjust values if needed.
+2. Start the stack:
+
+   ```sh
+   make start
+   # or
+   docker-compose up -d
+   ```
+
+3. Open [http://localhost:8080](http://localhost:8080) and follow the FreshRSS
+   installation wizard.
 
 ## Dependencies
 
+- Docker and Docker Compose
+- GNU Make
+- Optional: [mkcert](https://github.com/FiloSottile/mkcert) for local HTTPS
 
 ## Tech Stack
+
+- [FreshRSS](https://freshrss.org/) – self‑hosted RSS reader
+- [PostgreSQL](https://www.postgresql.org/) – persistent storage
+- Docker Compose – container orchestration

--- a/docs/techdocs/docs/architecture.md
+++ b/docs/techdocs/docs/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+The deployment runs two core services on a shared Docker network:
+
+```mermaid
+graph TD
+  A[FreshRSS\ncontainer]
+  B[(PostgreSQL\ninstance)]
+  A --> B
+```
+
+- **FreshRSS** handles the HTTP interface and periodic feed updates. Persistent data and user-installed extensions are mounted from host volumes.
+- **PostgreSQL** provides durable storage. Connection parameters are injected through the `.env` file.
+
+Each service attaches to the `webgrip` bridge network and persists data via dedicated Docker volumes, allowing containers to be recreated without data loss.

--- a/docs/techdocs/docs/dependencies.md
+++ b/docs/techdocs/docs/dependencies.md
@@ -1,0 +1,13 @@
+# Dependencies
+
+The following tools are required to develop and run the stack locally:
+
+- **Docker & Docker Compose** – container runtime and orchestration
+- **GNU Make** – convenience commands defined in the `Makefile`
+- **mkcert** (optional) – generate local CA certificates for HTTPS testing
+- **Helm** (optional) – linting and dependency management for Helm charts
+
+At runtime the application relies on:
+
+- **FreshRSS** – lightweight RSS reader written in PHP
+- **PostgreSQL** – relational database used for storage

--- a/docs/techdocs/docs/future-work.md
+++ b/docs/techdocs/docs/future-work.md
@@ -1,0 +1,9 @@
+# Future Work
+
+The following ideas are being explored to evolve the platform:
+
+- Support alternative databases such as SQLite for lightweight deployments.
+- Publish a Helm chart to simplify Kubernetes deployments.
+- Introduce high-availability mode with database replication and automatic failover.
+- Integrate observability tooling (Prometheus, Grafana) for runtime metrics.
+- Provide automated upgrade scripts to reduce maintenance effort.

--- a/docs/techdocs/docs/index.md
+++ b/docs/techdocs/docs/index.md
@@ -6,5 +6,13 @@ search:
   boost: 2
 ---
 
-Welcome to the freshrss-application documentation. Explore the architecture to learn how the platform collects, analyzes, and enriches news.
+Welcome to the freshrss-application documentation. This site describes the
+Docker based FreshRSS deployment that powers our internal news aggregator.
+
+Use the navigation to learn more about the platform:
+
+- **Architecture** – container layout and data flows
+- **Dependencies** – local tooling required to run the stack
+- **Future Work** – ideas being considered
+- **Planned Features** – enhancements already on the roadmap
 

--- a/docs/techdocs/docs/planned_features.md
+++ b/docs/techdocs/docs/planned_features.md
@@ -1,0 +1,24 @@
+# Planned Features
+
+These features are on the roadmap and will be prioritised in upcoming sprints:
+
+- OAuth2 and OpenID Connect authentication for multi-user instances
+- Automatic encrypted backups of database and extensions
+- Configurable feed refresh scheduler with per-feed overrides
+- Built-in Prometheus metrics endpoint
+- LDAP/Active Directory integration for enterprise deployments
+- Role-based access control with granular permissions
+- UI for tag and category management with bulk operations
+- Full-text search powered by PostgreSQL
+- Native dark mode and theme switcher
+- S3-compatible storage backend for media and uploads
+- Webhooks to notify external systems on feed updates
+- Rate limiting and retry policies to respect publisher limits
+- Web-based OPML import/export assistant with validation
+- Plugin marketplace for discovering and installing extensions
+- Configurable article retention and cleanup rules
+- Integration with read-it-later services like Pocket and Instapaper
+- Real-time feed refresh progress dashboard
+- Built-in health checks and alerting hooks
+- API token management interface for third-party apps
+- Multi-language user interface with community translations

--- a/docs/techdocs/mkdocs.yml
+++ b/docs/techdocs/mkdocs.yml
@@ -30,7 +30,6 @@ nav:
   - Home: index.md
   - Architecture: architecture.md
   - Dependencies: dependencies.md
-  - News-Please Config: news-please-config.md
   - Future Work: future-work.md
   - Planned Features: planned_features.md
 
@@ -50,7 +49,6 @@ plugins:
 
 markdown_extensions:
   - markdown_inline_mermaid
-  - markdown_inline_graphviz
 
 extra:
   analytics:


### PR DESCRIPTION
## Summary
- remove News-Please references from the documentation
- expand the roadmap with twenty actionable features
- clarify future work and deployment architecture

## Changelog
### Changed
- documented deployment architecture in more detail
- refined future work section with strategic initiatives
- expanded planned features list to twenty items
### Removed
- News-Please configuration page and navigation entry

## Testing
- `make pre-commit` *(fails: No rule to make target 'pre-commit')*
- `mkdocs build -f docs/techdocs/mkdocs.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a138ef8e208320afd3d505904e1467